### PR TITLE
Add require ham-mode statement

### DIFF
--- a/gmail-message-mode.el
+++ b/gmail-message-mode.el
@@ -94,6 +94,8 @@
 ;; 1.0   - 2013/12/05 - Created File.
 ;;; Code:
 
+(require 'ham-mode)
+
 (defconst gmail-message-mode-version "1.0.1" "Version of the gmail-message-mode.el package.")
 (defconst gmail-message-mode-version-int 2 "Version of the gmail-message-mode.el package, as an integer.")
 (defun gmail-message-mode-bug-report ()


### PR DESCRIPTION
Hi, @Bruce-Connor

Thank you for making cool package! I have wanted to edit gmail message with `Edit with Emacs`.

This commit fixes a following error:

```
gmail-message-mode: Symbol's function definition is void: ham-mode
```

Cheers,
-- Yasuyuki
